### PR TITLE
elm-community/easing-functions was missing from elm-package.json

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,6 +12,7 @@
     ],
     "dependencies": {
         "elm-community/list-extra": "3.1.0 <= v < 4.0.0",
+        "elm-community/easing-functions": "1.0.1 <= v < 2.0.0",
         "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",


### PR DESCRIPTION
That prevented the Showcase from working under `elm-reactor`.