### PR TITLE
Fixed a few documentation and comment misspellings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ case msg of
             )
 ```
 
-_Note!_ Make sure you're sending the cmds in the above code.  If you're note, then the animation will run, but the messages won't be sent.
+_Note!_ Make sure you're sending the cmds in the above code.  If you're not, then the animation will run, but the messages won't be sent.
 
 Also, if you're running this in a child component, make sure you're `Cmd.map`ing the child's commands back to the child or else the messages will be lost!
 

--- a/src/Animation.elm
+++ b/src/Animation.elm
@@ -272,7 +272,7 @@ defaultInterpolationByProperty prop =
                 }
 
         -- progress is set to 1 because it is changed to 0 when the animation actually starts
-        -- This is analagous to the spring starting at rest.
+        -- This is analogous to the spring starting at rest.
         linear duration =
             Easing
                 { progress = 1
@@ -430,7 +430,7 @@ styleWithEach props =
         initialState <| List.map (\( interp, prop ) -> mapToMotion (\m -> { m | interpolation = interp }) prop) props
 
 
-{-| Add an animation to the queue, execiting once the current animation finishes
+{-| Add an animation to the queue, executing once the current animation finishes
 
 -}
 queue : List (Animation.Model.Step msg) -> Animation msg -> Animation msg
@@ -1729,7 +1729,7 @@ offset value =
 
 {-| Given two lists of coordinates, rotate the list so that the lowest coordinate is first.
 
-This is to align polygon coordinates so that they can morph smoothely into each other.
+This is to align polygon coordinates so that they can morph smoothly into each other.
 -}
 alignStartingPoint : List ( Float, Float ) -> List ( Float, Float )
 alignStartingPoint points =

--- a/src/Animation/Model.elm
+++ b/src/Animation/Model.elm
@@ -447,7 +447,7 @@ updateAnimation (Tick now) (Animation model) =
         timing =
             refreshTiming now model.timing
 
-        -- Resolve potential interrutions
+        -- Resolve potential interruptions
         ( readyInterruption, queuedInterruptions ) =
             List.map
                 (\( wait, steps ) ->


### PR DESCRIPTION
Just a handful of spelling changes.  Most are in comments, but one is in the Readme documentation.