### PR TITLE
Expose `vh`, `vw`, `vmin` and `vmax` units

### DIFF
--- a/src/Animation.elm
+++ b/src/Animation.elm
@@ -122,6 +122,10 @@ module Animation
         , percent
         , em
         , rem
+        , vh
+        , vw
+        , vmin
+        , vmax
         , turn
         , deg
         , grad
@@ -161,7 +165,7 @@ module Animation
 @docs path, PathStep, move, moveTo, line, lineTo, horizontal, horizontalTo, vertical, verticalTo,  close, QuadraticCurve, curve, curveTo, CubicCurve, curve2, curve2To, arc, Arc
 
 # Units
-@docs px, percent, em, rem, turn, deg, grad, rad
+@docs px, percent, em, rem, turn, deg, grad, rad, vh, vw, vmin, vmax
 
 # Advanced
 @docs exactly, custom, custom2, customColor, attr, attr2, attr3, attr4, attrColor


### PR DESCRIPTION
These are fairly essential when doing page transitions or animating anything else that has to enter/exit completely off-screen.

Looks like they just needed to be exported, right?