### PR TITLE
Add usage of Animation.State to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ __Set an initial style__ in your model.
 ```elm
 import Animation exposing (px)
 
+type alias Model =
+    { style : Animation.State }
+
 init : Model
 init =
     { style = 


### PR DESCRIPTION
Even with the note in the README about Animation.State, it took me about a half an hour of hunting to figure out how to type my model. This should clear things up.